### PR TITLE
Fixed build script when it doesn't run on a *curses terminal and dropped hardcoded prefix for package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs": "./node_modules/.bin/typedoc.cmd --out dist/docs --mode modules ./src/"
   },
   "bin": {
-    "androidjs": "./dist/bin.js"
+    "androidjs": "./dist/src/bin.js"
   },
   "dependencies": {
     "@types/jest": "^25.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs": "./node_modules/.bin/typedoc.cmd --out dist/docs --mode modules ./src/"
   },
   "bin": {
-    "androidjs": "./dist/src/bin.js"
+    "androidjs": "./dist/bin.js"
   },
   "dependencies": {
     "@types/jest": "^25.1.3",

--- a/src/modules/Html/ManifestBuilder.ts
+++ b/src/modules/Html/ManifestBuilder.ts
@@ -91,7 +91,7 @@ export function getManifest(env: IEnv, args, permissions: Array<string>, deep_li
         name: 'manifest',
         keys: {
             'xmlns:android': "http://schemas.android.com/apk/res/android",
-            'package':`com.androidjs.${package_name}`,
+            'package': package_name,
             platformBuildVersionCode: env_manifist.platformBuildVersionCode,
             platformBuildVersionName: env_manifist.platformBuildVersionName
         }

--- a/src/modules/Html/ProgressBar.ts
+++ b/src/modules/Html/ProgressBar.ts
@@ -96,8 +96,7 @@ export class ProgressBar {
 
         this.clearLine();
         const _str = `  ${_p}% : ${chalk.green(this.bar_fill.repeat(_left-1)+_in_progress_code)}${ this.barr_empty.repeat(_right)}`;
-        if (process.stdout.write)
-            process.stdout.write(_str);
+        process.stdout?.write(_str);
         // console.log(_left, _right)
     }
     clearLine() {

--- a/src/modules/Html/ProgressBar.ts
+++ b/src/modules/Html/ProgressBar.ts
@@ -100,11 +100,9 @@ export class ProgressBar {
         // console.log(_left, _right)
     }
     clearLine() {
-        if (process.stdout.clearLine)
-            //@ts-ignore
-            process.stdout.clearLine();
-        if (process.stdout.cursorTo)
-            //@ts-ignore
-            process.stdout.cursorTo(0);
+        //@ts-ignore
+        process.stdout?.clearLine();
+        //@ts-ignore
+        process.stdout?.cursorTo(0);
     }
 }

--- a/src/modules/Html/ProgressBar.ts
+++ b/src/modules/Html/ProgressBar.ts
@@ -39,13 +39,16 @@ export class LoadingBar{
         let _left = this.currentIndex - 1;
         _left = _left < 0 ? 0 : _left;
         let _right = this.bar_length - _left - 1;
-        process.stdout.write(`${this.message}${this.chunksDownloaded} :` + chalk.green(` ${this.empty.repeat(_left)}${this.fill}${this.empty.repeat(_right)}`));
+        if (process.stdout.write)
+            process.stdout.write(`${this.message}${this.chunksDownloaded} :` + chalk.green(` ${this.empty.repeat(_left)}${this.fill}${this.empty.repeat(_right)}`));
     }
     clear(){
-        //@ts-ignore
-        process.stdout.clearLine();
-        //@ts-ignore
-        process.stdout.cursorTo(0);
+        if (process.stdout.clearLine)
+            //@ts-ignore
+            process.stdout.clearLine();
+        if (process.stdout.cursorTo)
+            //@ts-ignore
+            process.stdout.cursorTo(0);
     }
 
     start(speed?:number) {
@@ -83,7 +86,7 @@ export class ProgressBar {
     constructor(total?:number) {
         this.total = total || null;
         this.current = 0;
-        this.bar_length = process.stdout.columns - 30;
+        this.bar_length = process.stdout.columns ? process.stdout.columns - 30 : 0;
         // this.bar_length = 50;
     }
     next(progress) {
@@ -96,13 +99,16 @@ export class ProgressBar {
 
         this.clearLine();
         const _str = `  ${_p}% : ${chalk.green(this.bar_fill.repeat(_left-1)+_in_progress_code)}${ this.barr_empty.repeat(_right)}`;
-        process.stdout.write(_str);
+        if (process.stdout.write)
+            process.stdout.write(_str);
         // console.log(_left, _right)
     }
     clearLine() {
-        //@ts-ignore
-        process.stdout.clearLine();
-        //@ts-ignore
-        process.stdout.cursorTo(0);
+        if (process.stdout.clearLine)
+            //@ts-ignore
+            process.stdout.clearLine();
+        if (process.stdout.cursorTo)
+            //@ts-ignore
+            process.stdout.cursorTo(0);
     }
 }

--- a/src/modules/Html/ProgressBar.ts
+++ b/src/modules/Html/ProgressBar.ts
@@ -39,8 +39,7 @@ export class LoadingBar{
         let _left = this.currentIndex - 1;
         _left = _left < 0 ? 0 : _left;
         let _right = this.bar_length - _left - 1;
-        if (process.stdout.write)
-            process.stdout.write(`${this.message}${this.chunksDownloaded} :` + chalk.green(` ${this.empty.repeat(_left)}${this.fill}${this.empty.repeat(_right)}`));
+        process.stdout?.write(`${this.message}${this.chunksDownloaded} :` + chalk.green(` ${this.empty.repeat(_left)}${this.fill}${this.empty.repeat(_right)}`));
     }
     clear(){
         if (process.stdout.clearLine)

--- a/src/modules/Html/ProgressBar.ts
+++ b/src/modules/Html/ProgressBar.ts
@@ -42,12 +42,10 @@ export class LoadingBar{
         process.stdout?.write(`${this.message}${this.chunksDownloaded} :` + chalk.green(` ${this.empty.repeat(_left)}${this.fill}${this.empty.repeat(_right)}`));
     }
     clear(){
-        if (process.stdout.clearLine)
-            //@ts-ignore
-            process.stdout.clearLine();
-        if (process.stdout.cursorTo)
-            //@ts-ignore
-            process.stdout.cursorTo(0);
+        //@ts-ignore
+        process.stdout?.clearLine();
+        //@ts-ignore
+        process.stdout?.cursorTo(0);
     }
 
     start(speed?:number) {


### PR DESCRIPTION
This PR provides:

- A (very dirty) fix for [#126](https://github.com/android-js/androidjs/issues/126). When `androidjs build` is run from a non-interactive terminal (e.g. a Docker build, a Makefile, an F-Droid build, or launched/piped from a non-interactive script) it won't have access to the *curses primitives, and therefore calls to methods such as `clearLine` and `cursorTo` will fail. Note however that this is a *very dirty* fix that simply skips those calls if the methods aren't available, but will still print out a lot of ugly all-on-one-line content that was supposed to be a progress bar. The intent is to open a discussion on what's the best approach to deal with this case - I see two options: either entirely disable the `ProgressBar` output if the advanced terminal drawing features are not available, or add some kind of `--no-interactive` option to run the script without terminal drawing options.

- Removed the `com.androidjs` hardcoded prefix in the manifest generator. Hardcoding the package prefix will almost certainly conflict with the `package-name` specified on the `package.json` and result in failures when trying to upload the app to any store.